### PR TITLE
Create jira issue

### DIFF
--- a/server/api.py
+++ b/server/api.py
@@ -434,3 +434,19 @@ def create_repo(details, repo_name):
             print("Repository created")
     except requests.RequestException as e:
         print("Exception::", str(e))
+
+
+from create_jira_issue import ProjectDetails, create_issue
+
+
+# Creating end point
+@app.post("/create_jira")
+def create(details: ProjectDetails):
+    """
+    Endpoint for Jira issue creation
+    """
+    try:
+        return create_issue(details)
+    except (CalledProcessError, Exception) as error:
+        logger.exception("Error occurred: %s", error)
+        raise HTTPException(status_code=500, detail=f"Error occurred:\n\n{error.stdout.decode()}")

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -1,0 +1,61 @@
+import json
+import os
+import requests
+
+
+def create_issue(issue_summary="Default issue summary, created from python", description_text="default description"):
+    # Retrieve the API key secret from the environment
+    BASIC = os.environ.get('JIRA_API_BASIC')  # Should be retrieved from google secret manager and injected w/ Helm
+
+    # Prepare the request
+    content_type = "application/json"
+    url = "https://statistics-norway.atlassian.net/rest/api/3/issue"
+    headers = {"Content-Type": content_type, "Authorization": f"Basic {BASIC}"}
+    issue_json = get_issue_json(issue_summary=issue_summary, description_text=description_text)
+
+    # Send the issue creation request to Jira
+    print("POST new issue")
+    r = requests.post(url, headers=headers, data=issue_json)
+    print(f"status code {r.status_code} text {r.text}")
+    return r.status_code
+
+
+def get_issue_json(issue_summary="Default issue summary, created from python", description_text="default description"):
+    issue_dict = {
+        "fields": {
+            "project": {
+                "key": "DS"  # DS is the 'key' for the Dapla Start project
+            },
+            "summary": issue_summary,
+            "description": {
+                "type": "doc",
+                "version": 1,
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [
+                            {
+                                "text": description_text,
+                                "type": "text"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "issuetype": {
+                "name": "Task"
+            }
+        }
+    }
+    return json.dumps(issue_dict)
+
+
+if __name__ == "__main__":
+    issue_summary = "Top Text"
+    issue_description = f""" bottom 👉👈 text
+    
+    This issue was created from a Python 🐍 script as a test ✅
+    This is a multi-line f-string 🇫🧵 with variables inserted 💉 
+    For example, here comes the issue_summary: "{issue_summary}".
+    """
+    create_issue(issue_summary, issue_description)

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -26,8 +26,6 @@ def create_issue(issue_summary, description_text):
     if basic is None or len(basic) == 0:
         print('ABORTING! The env variable JIRA_API_BASIC must be set to be your base64 encoded "email:APIkey" string.')
         exit(1)
-    else:
-        print('Basic authentication string was retrieved from the JIRA_API_BASIC environment variable')
 
     # Prepare the request
     content_type = "application/json"
@@ -154,7 +152,7 @@ def get_issue_description(details: ProjectDetails):
     Teamets leder(e): {details.manager_email_list}
         AD-gruppe: {mgm_group}
         
-    Teamets dataadministratorer: {details.dpo_email_list}
+    Teamets dataadministrator(er): {details.dpo_email_list}
         AD-gruppe: {mgm_group}
     
     Fint om dere kan ordne det!

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -1,23 +1,45 @@
 import json
 import os
+from typing import List
 import requests
+from pydantic import BaseModel
 
 
-def create_issue(issue_summary="Default issue summary, created from python", description_text="default description"):
+class ProjectDetails(BaseModel):
+    display_team_name: str
+    uniform_team_name: str
+    manager_email_list: List[str]
+    dpo_email_list: List[str]
+    dev_email_list: List[str]
+    consumer_email_list: List[str]
+    service_list: List[str]
+
+
+def create_dapla_start_issue(details: ProjectDetails):
+    issue_summary, description_text = get_issue_description(details)
+    return create_issue(issue_summary, description_text)
+
+
+def create_issue(issue_summary, description_text):
     # Retrieve the API key secret from the environment
-    BASIC = os.environ.get('JIRA_API_BASIC')  # Should be retrieved from google secret manager and injected w/ Helm
+    basic = os.environ.get('JIRA_API_BASIC')
+    if basic is None or len(basic) == 0:
+        print('ABORTING! The env variable JIRA_API_BASIC must be set to be your base64 encoded "email:APIkey" string.')
+        exit(1)
+    else:
+        print('Basic authentication string was retrieved from the JIRA_API_BASIC environment variable')
 
     # Prepare the request
     content_type = "application/json"
     url = "https://statistics-norway.atlassian.net/rest/api/3/issue"
-    headers = {"Content-Type": content_type, "Authorization": f"Basic {BASIC}"}
+    headers = {"Content-Type": content_type, "Authorization": f"Basic {basic}"}
     issue_json = get_issue_json(issue_summary=issue_summary, description_text=description_text)
 
     # Send the issue creation request to Jira
     print("POST new issue")
     r = requests.post(url, headers=headers, data=issue_json)
     print(f"status code {r.status_code} text {r.text}")
-    return r.status_code
+    return r
 
 
 def get_issue_json(issue_summary="Default issue summary, created from python", description_text="default description"):
@@ -50,7 +72,111 @@ def get_issue_json(issue_summary="Default issue summary, created from python", d
     return json.dumps(issue_dict)
 
 
-if __name__ == "__main__":
+def get_issue_description(details: ProjectDetails):
+    """
+    This function generates the issue description which contains all the information needed in order to complete
+    the creation of a Dapla team
+    :param details: Contains all required information
+    :return: The summary and complete issue description containing all information needed to create a Dapla team
+    """
+    summary = f"On-boarding: {details.display_team_name}"  # This is the "header" of the Jira issue
+    iac_git_project_name = f"dapla-team-{details.uniform_team_name}"
+    domain = "@groups.ssb.no"
+    mgm_group = f"{details.uniform_team_name}-managers{domain}"
+    dpo_group = f"{details.uniform_team_name}-data-protection-officers{domain}"
+    dev_group = f"{details.uniform_team_name}-developers{domain}"
+    con_group = f"{details.uniform_team_name}-consumers{domain}"
+
+    # The body of the jira issue
+    description = f"""Display team name: '{details.display_team_name}'
+    Team name: '{details.uniform_team_name}'
+    IAC GIT project name: '{iac_git_project_name}'
+    
+    ** 1. AD group creation  **
+    These AD groups should be created for the team. It's fastest to ask Magnus Myrdal Jenssen, 
+    but kundeservice@ssb.no can also do it if he is away.
+    
+    Managers:
+        AD group: {mgm_group}
+        members: {details.manager_email_list}
+        
+    Data Protection Officers:
+        AD group: {dpo_group}
+        members: {details.dpo_email_list}
+        
+    Developers:
+        AD group: {dev_group}
+        members: {details.dev_email_list}
+        
+    Consumers:
+        AD group: {con_group}
+        members: {details.consumer_email_list}
+        
+    
+    ** 2. bip-gcp-base-config **
+    AFTER AD groups have been created, add the following line:
+    "{details.uniform_team_name}" : "{mgm_group}
+    
+    ...to the dictionary in this file: 
+    https://github.com/statisticsnorway/bip-gcp-base-config/blob/main/terraform.tfvars
+ 
+ 
+    ** 3. Create GCP Team IAC GIT repository **
+    IAC GIT project name: '{iac_git_project_name}'
+    dapla-start has support for iac git repo creation using terraform templates. Now would be the time to use it!
+    
+    There should probably be a dump of all the info needed for the github project here:
+    
+    
+    ** 4. Atlantis Whitelist **
+    Once the IAC git repository has been created, it needs to be whitelisted by BIP Atlantis. 
+    
+    Hei Stratus, kan dere Atlantis-whiteliste repoet '{iac_git_project_name}'?
+    
+    
+    ** 5. Apply terraform with Atlantis **
+    Create a pull request in '{iac_git_project_name}' 
+    and run the "Atlantis apply" command in the pull request before you merge and delete the branch.
+    This will cause Atlantis to build our requested infrastructure in GCP.
+ 
+ 
+    ** 6. Additional Services **
+    Requested services: {details.service_list}
+    
+    If transfer service is requested, send a request to Kundeservice. 
+    Kundeservice needs to set up the transfer service agent and directory in linuxstammen.
+    
+    '''
+    Hei Kundeservice,
+    
+    Det nye dapla teamet '{details.display_team_name}' ({details.uniform_team_name}) trenger transfer service satt opp for seg.
+    
+    Teamets leder(e): {details.manager_email_list}
+        AD-gruppe: {mgm_group}
+        
+    Teamets dataadministratorer: {details.dpo_email_list}
+        AD-gruppe: {mgm_group}
+    
+    Fint om dere kan ordne det!
+    
+    Vennlig hilsen,
+    '''
+    
+    After kundeservice has activated the agent and created the directory structure in linuxstammen, 
+    you can refer the managers ({details.manager_email_list}) and/or DPOs ({details.dpo_email_list}) to the docs
+    for activating the transfer service on the GCP side:
+    
+    https://docs.dapla.ssb.no/dapla-user/transfer/
+    
+    ** Done! **
+    
+    Congratulations, if everything went according to plan, you are now done!
+    
+    """
+    return summary, description
+
+
+def generic_issue_creation_test():
     issue_summary = "Top Text"
     issue_description = f""" bottom 👉👈 text
     
@@ -58,4 +184,44 @@ if __name__ == "__main__":
     This is a multi-line f-string 🇫🧵 with variables inserted 💉 
     For example, here comes the issue_summary: "{issue_summary}".
     """
+    authentication_env_var = 'JIRA_API_BASIC'
+    basic = os.environ.get(authentication_env_var)
+    if basic is None or len(basic) == 0:
+        os.environ[authentication_env_var] = ""  # insert base64 encoded "email:key" here
+        basic = os.environ.get(authentication_env_var)
+        if basic is None or len(basic) == 0:
+            print(f'The env variable {authentication_env_var} must be set to be a base64 encoded "email:key" string')
+            exit(1)
+
     create_issue(issue_summary, issue_description)
+
+
+if __name__ == "__main__":
+    """
+    This main is for the purposes of testing the jira issue creation functionality.
+    """
+
+    # Basic auth
+    authentication_env_var = 'JIRA_API_BASIC'
+    basic = os.environ.get(authentication_env_var)
+    if basic is None or len(basic) == 0:
+        os.environ[authentication_env_var] = ""  # insert base64 encoded "email:key" here
+        basic = os.environ.get(authentication_env_var)
+        if basic is None or len(basic) == 0:
+            print(f'The env variable {authentication_env_var} must be set to be a base64 encoded "email:key" string')
+            exit(1)
+
+    # Team info
+    det_dict = {
+        "display_team_name": "Team Domene Subdomene",
+        "uniform_team_name": "domene-subdomene",
+        "manager_email_list": ["erv@ssb.no"],
+        "dpo_email_list": ["mmj@ssb.no"],
+        "dev_email_list": ["old@ssb.no", "xyz@ssb.no"],
+        "consumer_email_list": ["abc@ssb.no", "def@ssb.no"],
+        "service_list": ["transfer service"]
+    }
+    project_details = ProjectDetails.parse_obj(det_dict)
+
+    # Creation
+    create_dapla_start_issue(project_details)


### PR DESCRIPTION
The dapla-start-api now takes POST requests on `/create_jira`

The body should be a JSON on this format:
```
{
        "display_team_name": "Team Domene Subdomene",
        "uniform_team_name": "domene-subdomene",
        "manager_email_list": ["erv@ssb.no"],
        "dpo_email_list": ["mmj@ssb.no"],
        "dev_email_list": ["old@ssb.no", "xyz@ssb.no"],
        "consumer_email_list": ["abc@ssb.no", "def@ssb.no"],
        "service_list": ["transfer service"]
}
```

If the project should not have "transfer service" enabled, it should not be included in the services list.

The ENV variable `JIRA_API_BASIC` has to be set to a base64-encoded "email:api-key" string in the container where the service in running in order for this to work.

The end result is that an issue [like this](https://statistics-norway.atlassian.net/browse/DS-8) is created in the Dapla Start board.