### PR TITLE
Oauth2 3lo

### DIFF
--- a/server/api.py
+++ b/server/api.py
@@ -447,9 +447,8 @@ from .create_jira_issue import ProjectDetails, create_dapla_start_issue, get_aut
     create_issue_basic
 
 
-# Jira issue creation end point
 @app.post("/create_jira_basic", status_code=201)
-def create_issue(details: ProjectDetails):
+def create_issue_basic(details: ProjectDetails):
     """
     Endpoint for Jira issue creation using basic auth
     """
@@ -464,9 +463,8 @@ def create_issue(details: ProjectDetails):
         raise HTTPException(status_code=500, detail=f"Error occurred:\n\n{error.stdout.decode()}")
 
 
-# Jira issue creation end point
 @app.post("/create_jira_3LO", status_code=201)
-def create_issue(details: ProjectDetails):
+def create_issue_3lo(details: ProjectDetails):
     """
     Endpoint for Jira issue creation using 3LO
     """

--- a/server/api.py
+++ b/server/api.py
@@ -443,12 +443,12 @@ def create_repo(details, repo_name):
         print("Exception::", str(e))
 
 
-from .create_jira_issue import ProjectDetails, create_dapla_start_issue
+from .create_jira_issue import ProjectDetails, create_dapla_start_issue, get_authorization_url
 
 
-# Creating end point
+# Jira issue creation end point
 @app.post("/create_jira", status_code=201)
-def create(details: ProjectDetails):
+def create_issue(details: ProjectDetails):
     """
     Endpoint for Jira issue creation
     """
@@ -461,3 +461,19 @@ def create(details: ProjectDetails):
     except (CalledProcessError, Exception) as error:
         logger.exception("Error occurred: %s", error)
         raise HTTPException(status_code=500, detail=f"Error occurred:\n\n{error.stdout.decode()}")
+
+
+@app.get("/auth_url", status_code=200)
+def auth_url(user_bound_value: str):
+    """
+    Endpoint for authorization url creation
+    """
+    try:
+        print(f"Got an auth_url request. Details: {user_bound_value}")
+        user_auth_url = get_authorization_url(user_bound_value)
+        response_data = {"auth_url": user_auth_url, "user_bound_value": user_bound_value}
+        return response_data
+    except Exception as error:
+        logger.exception("Error occurred: %s", error)
+        raise HTTPException(status_code=500, detail=f"Error occurred:\n\n{error.stdout.decode()}")
+

--- a/server/api.py
+++ b/server/api.py
@@ -464,14 +464,14 @@ def create_issue(details: ProjectDetails):
 
 
 @app.get("/auth_url", status_code=200)
-def auth_url(user_bound_value: str):
+def auth_url(state: str):
     """
     Endpoint for authorization url creation
     """
     try:
-        print(f"Got an auth_url request. Details: {user_bound_value}")
-        user_auth_url = get_authorization_url(user_bound_value)
-        response_data = {"auth_url": user_auth_url, "user_bound_value": user_bound_value}
+        print(f"Got an auth_url request. Details: {state}")
+        user_auth_url = get_authorization_url(state)
+        response_data = {"auth_url": user_auth_url, "state": state}
         return response_data
     except Exception as error:
         logger.exception("Error occurred: %s", error)

--- a/server/api.py
+++ b/server/api.py
@@ -443,20 +443,38 @@ def create_repo(details, repo_name):
         print("Exception::", str(e))
 
 
-from .create_jira_issue import ProjectDetails, create_dapla_start_issue, get_authorization_url
+from .create_jira_issue import ProjectDetails, create_dapla_start_issue, get_authorization_url, create_jira_issue_3lo, \
+    create_issue_basic
 
 
 # Jira issue creation end point
-@app.post("/create_jira", status_code=201)
+@app.post("/create_jira_basic", status_code=201)
 def create_issue(details: ProjectDetails):
     """
-    Endpoint for Jira issue creation
+    Endpoint for Jira issue creation using basic auth
     """
     try:
-        print("Got a jira issue creation request.")
+        print("Got a jira issue creation request, using Basic auth.")
         print("Details:")
         print(details)
-        response_from_jira = create_dapla_start_issue(details)
+        response_from_jira = create_issue_basic(details)
+        return json.loads(response_from_jira.text)
+    except (CalledProcessError, Exception) as error:
+        logger.exception("Error occurred: %s", error)
+        raise HTTPException(status_code=500, detail=f"Error occurred:\n\n{error.stdout.decode()}")
+
+
+# Jira issue creation end point
+@app.post("/create_jira_3LO", status_code=201)
+def create_issue(details: ProjectDetails):
+    """
+    Endpoint for Jira issue creation using 3LO
+    """
+    try:
+        print("Got a jira issue creation request, using 3LO auth.")
+        print("Details:")
+        print(details)
+        response_from_jira = create_jira_issue_3lo(details)
         return json.loads(response_from_jira.text)
     except (CalledProcessError, Exception) as error:
         logger.exception("Error occurred: %s", error)

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -193,7 +193,7 @@ def generic_issue_creation_test():
     create_issue_basic(issue_summary, issue_description)
 
 
-def get_authorization_url(client_id="3mvYlLJX466VodaubZTD0WcpOSHOnAqa", user_bound_value=""):
+def get_authorization_url(user_bound_value, client_id="3mvYlLJX466VodaubZTD0WcpOSHOnAqa"):
     url_string = (f"https://auth.atlassian.com/authorize"
                   f"?audience=api.atlassian.com"
                   f"&client_id={client_id}"

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -193,7 +193,7 @@ def generic_issue_creation_test():
     create_issue_basic(issue_summary, issue_description)
 
 
-def get_authorization_url(user_bound_value, client_id="3mvYlLJX466VodaubZTD0WcpOSHOnAqa"):
+def get_authorization_url(state, client_id="3mvYlLJX466VodaubZTD0WcpOSHOnAqa"):
     url_string = (f"https://auth.atlassian.com/authorize"
                  f"?audience=api.atlassian.com"
                  f"&client_id={client_id}"
@@ -201,7 +201,7 @@ def get_authorization_url(user_bound_value, client_id="3mvYlLJX466VodaubZTD0WcpO
                  f"&redirect_uri=https%3A%2F%2Fstart.dapla.ssb.no%2F2"
                  f"&response_type=code"
                  f"&prompt=consent"
-                 f"&state=${user_bound_value}") # (required for security) Set this to a value that is associated with the user you are directing to the authorization URL, for example, a hash of the user's session ID.
+                 f"&state=${state}") # (required for security) Set this to a value that is associated with the user you are directing to the authorization URL, for example, a hash of the user's session ID.
     # If successful, the user will be redirected to the app's callback URL,
     # with an authorization code provided as a query parameter called code.
     # This code can be exchanged for an access token, as described in step 2.

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -192,6 +192,43 @@ def generic_issue_creation_test():
     create_issue(issue_summary, issue_description)
 
 
+def get_authorization_url(client_id="3mvYlLJX466VodaubZTD0WcpOSHOnAqa", user_bound_value=""):
+    url_string = (f"https://auth.atlassian.com/authorize"
+                  f"?audience=api.atlassian.com"
+                  f"&client_id={client_id}"
+                  f"&scope=read%3Ajira-user%20write%3Ajira-work%20read%3Ajira-work"
+                  f"&redirect_uri=https%3A%2F%2Fstart.dapla.ssb.no%2F"
+                  f"&state={user_bound_value}"  # (required for security) Set this to a value that is associated with the user you are directing to the authorization URL, for example, a hash of the user's session ID.
+                  f"&response_type=code&prompt=consent")
+    # If successful, the user will be redirected to the app's callback URL,
+    # with an authorization code provided as a query parameter called code.
+    # This code can be exchanged for an access token, as described in step 2.
+    return url_string
+
+
+def get_access_token(authorization_code, client_id="3mvYlLJX466VodaubZTD0WcpOSHOnAqa", callback_url="https://start.dapla.ssb.no/"):
+    atlassian_oauth_token_url = "https://auth.atlassian.com/oauth/token"
+    client_secret = os.getenv("OAUTH_2_CLIENT_SECRET")
+    headers = {"Content-Type": "application/json"}
+    data = {"grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "code": authorization_code,
+            "redirect_uri": callback_url}
+    r = requests.get(atlassian_oauth_token_url, headers=headers, data=json.dumps(data))
+    return r
+
+
+def get_cloud_id(access_token):
+    accessible_resources_url = "https://api.atlassian.com/oauth/token/accessible-resources"
+    headers = {"Authorization": f"Bearer {access_token}"}
+    accessible_resources_response = requests.get(url=accessible_resources_url, headers=headers)
+    data = json.loads(accessible_resources_response.text)
+    cloud_id = data[0]["id"]
+    return cloud_id
+
+def make_3lo_request(api="/rest/api/3/issue", )
+
 if __name__ == "__main__":
     """
     This main is for the purposes of testing the jira issue creation functionality.

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 
 
 class ProjectDetails(BaseModel):
-    authorization_code: str
     display_team_name: str
     uniform_team_name: str
     manager_email_list: List[str]
@@ -14,6 +13,7 @@ class ProjectDetails(BaseModel):
     dev_email_list: Optional[List[str]]
     consumer_email_list: Optional[List[str]]
     service_list: Optional[List[str]]
+    authorization_code: Optional[str]
 
 
 def create_dapla_start_issue(details: ProjectDetails):
@@ -241,6 +241,14 @@ def get_cloud_id(access_token):
 
 
 def create_jira_issue_3lo(details, client_id="3mvYlLJX466VodaubZTD0WcpOSHOnAqa", callback_url="https://start.dapla.ssb.no/2", api="/rest/api/3/issue"):
+    """
+
+    :param details: Must contain the authorization_code optional field! This can be retrieved from the auth step.
+    :param client_id:
+    :param callback_url:
+    :param api:
+    :return:
+    """
     print(f"[DEBUG] jira issue creation 3LO method started...")
     issue_summary, description_text = get_issue_description(details)
     get_access_token_response = get_access_token(details.authorization_code, client_id, callback_url)


### PR DESCRIPTION
3LO flow works when I walk through it manually with locally running backend, postman, and auth code from the generated link. 

Suggested change to the front end,  if we want to make 3LO work:

* A button somewhere in the flow should take the user to the auth link with the next step of the flow set as the callback.

Long version:

Auth step happens when the user clicks "Sett i gang" at the first screen OR when they push the final button on the last screen (or both?). If the Authorization code expires quickly, it should be done right before submitting. Otherwise it's nice to do it at the beginning, so that the user doesn't waste time filling out the form if they don't have a valid jira user.

To complete the auth step, users should get taken to a Jira authorization link retrieved from the response body of a GET request to the `/auth_url` endpoint of this back-end. The endpoint takes state as a the `state` query parameter. Must be/contain a unique identifier for the user session. Returns JSON containing the the fields `state` and `auth_url`.

At the Jira auth screen linked to in the auth_url, the user simply has to click "Accept", and get taken back to the front end. I've currently set the callback to be `https://start.dapla.ssb.no/2`, based on the assumption that the user performs the auth code retrieval step at the beginning. This is easy to change. The authorization `code` will be included as a query parameter at the callback url, together with the `state` that was input. The authorization code retrieved from the `code` query parameter must be included in the body of the POST request to `/create_jira`, as a field called `authorization_code`.