### PR TITLE
Added basic instrumentation using prometheus-fastapi-instrumentator

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -398,6 +398,29 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "prometheus-client"
+version = "0.12.0"
+description = "Python client for the Prometheus monitoring system."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
+name = "prometheus-fastapi-instrumentator"
+version = "5.7.1"
+description = "Instrument your FastAPI with Prometheus metrics"
+category = "main"
+optional = false
+python-versions = ">=3.6.0,<4.0.0"
+
+[package.dependencies]
+fastapi = ">=0.38.1,<1.0.0"
+prometheus-client = ">=0.8.0,<1.0.0"
+
+[[package]]
 name = "pudb"
 version = "2021.2.2"
 description = "A full-screen, console-based Python debugger"
@@ -696,7 +719,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "f9bb77814d5204158e5d1a59841fa4fad590d452e9ee951f2f2df2329031847d"
+content-hash = "1576fab787519868bcfab8b1d75dcaa6109458a1af58eba3aa521f9879bd40fb"
 
 [metadata.files]
 anyio = [
@@ -983,6 +1006,14 @@ pluggy = [
 poyo = [
     {file = "poyo-0.5.0-py2.py3-none-any.whl", hash = "sha256:3e2ca8e33fdc3c411cd101ca395668395dd5dc7ac775b8e809e3def9f9fe041a"},
     {file = "poyo-0.5.0.tar.gz", hash = "sha256:e26956aa780c45f011ca9886f044590e2d8fd8b61db7b1c1cf4e0869f48ed4dd"},
+]
+prometheus-client = [
+    {file = "prometheus_client-0.12.0-py2.py3-none-any.whl", hash = "sha256:317453ebabff0a1b02df7f708efbab21e3489e7072b61cb6957230dd004a0af0"},
+    {file = "prometheus_client-0.12.0.tar.gz", hash = "sha256:1b12ba48cee33b9b0b9de64a1047cbd3c5f2d0ab6ebcead7ddda613a750ec3c5"},
+]
+prometheus-fastapi-instrumentator = [
+    {file = "prometheus-fastapi-instrumentator-5.7.1.tar.gz", hash = "sha256:5371f1b494e2b00017a02898d854119b4929025d1a203670b07b3f42dd0b5526"},
+    {file = "prometheus_fastapi_instrumentator-5.7.1-py3-none-any.whl", hash = "sha256:da40ea0df14b0e95d584769747fba777522a8df6a8c47cec2edf798f1fff49b5"},
 ]
 pudb = [
     {file = "pudb-2021.2.2.tar.gz", hash = "sha256:82a524ab4b89d2c701b089071ccc6afa9c8a838504e3d68eb33faa8a8abbe4cb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ isort = "^5.10.1"
 cookiecutter = "^1.7.3"
 requests = "^2.26.0"
 cryptography = "^3.2"
+prometheus-fastapi-instrumentator = "^5.7.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/server/api.py
+++ b/server/api.py
@@ -22,8 +22,10 @@ from fastapi.middleware.cors import CORSMiddleware
 from github import Github, GithubException
 from pydantic import BaseModel
 from requests.structures import CaseInsensitiveDict
+from prometheus_fastapi_instrumentator import Instrumentator
 
 app = FastAPI()
+Instrumentator().instrument(app).expose(app)
 
 origins = ["*"]
 


### PR DESCRIPTION
This will expose a /metrics endpoint and provide basic metrics for http requests.

More metrics can be added later