### PR TITLE
unicode support and tech details field name fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ requests = "^2.26.0"
 PyYAML = "^6.0"
 prometheus-fastapi-instrumentator = "^5.7.1"
 PyJWT = "^2.3.0"
-jsonschema = "^4.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requests = "^2.26.0"
 PyYAML = "^6.0"
 prometheus-fastapi-instrumentator = "^5.7.1"
 PyJWT = "^2.3.0"
+jsonschema = "^4.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     det_dict = {
         "display_team_name": "Team Domene Subdomene",
         "manager": xxx_mail,
-        "data_protection-officers": [xxx_mail],
+        "data_admin": [xxx_mail],
         "developers": [xxx_mail, xxx_mail],
         "consumers": [xxx_mail, xxx_mail],
         "enabled_services": ["transfer service"]

--- a/server/create_jira_issue.py
+++ b/server/create_jira_issue.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
     det_dict = {
         "display_team_name": "Team Domene Subdomene",
         "manager": xxx_mail,
-        "data_admin": [xxx_mail],
+        "data_admins": [xxx_mail],
         "developers": [xxx_mail, xxx_mail],
         "consumers": [xxx_mail, xxx_mail],
         "enabled_services": ["transfer service"]

--- a/server/jira_issue_adf_template.py
+++ b/server/jira_issue_adf_template.py
@@ -41,7 +41,7 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
     technical_details = {
         "display_team_name": details.display_team_name,
         "uniform_team_name": uniform_team_name,
-        "github_project_name": iac_git_project_name
+        "github_repo_name": iac_git_project_name
     }
 
     if details.enabled_services and isinstance(details.enabled_services, list):
@@ -685,7 +685,7 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
                 "content": [
                     {
                         "type": "text",
-                        "text": f"{yaml.dump(technical_details, sort_keys=False)}"
+                        "text": f"{yaml.dump(technical_details, sort_keys=False, allow_unicode=True)}"
                     }
                 ]
             },

--- a/server/jira_issue_adf_template.py
+++ b/server/jira_issue_adf_template.py
@@ -35,7 +35,7 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
     iac_git_project_name = f"dapla-team-{uniform_team_name}"
     domain = "@groups.ssb.no"
     mgm_group = f"{uniform_team_name}-managers{domain}"
-    dpo_group = f"{uniform_team_name}-data-protection-officers{domain}"
+    dpo_group = f"{uniform_team_name}-data-admins{domain}"
     dev_group = f"{uniform_team_name}-developers{domain}"
     con_group = f"{uniform_team_name}-consumers{domain}"
     technical_details = {
@@ -534,7 +534,7 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
                         "content": [
                             {
                                 "type": "text",
-                                "text": f"Det nye dapla teamet '{details.display_team_name}' trenger transfer service satt opp for seg."
+                                "text": f"Det nye Dapla teamet '{details.display_team_name}' trenger Transfer Service satt opp for seg."
                             }
                         ]
                     },
@@ -608,9 +608,8 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
                         "type": "text",
                         "text": "Etter at Kundeservice har satt opp agenten og opprettet en katalogstruktur på "
                                 f"Linuxstammen kan du henvise til teamets Manager ({details.manager.name}) og/eller en "
-                                "Data Protection Officer "                            
-                                "til følgende dokument som beskriver hvordan man setter opp Transfer Service på "
-                                "Google Cloud Platform:"
+                                "Data Admin til følgende dokument som beskriver hvordan man setter opp Transfer Service "
+                                "på Google Cloud Platform:"
                     }
                 ]
             },

--- a/server/jira_issue_adf_template.py
+++ b/server/jira_issue_adf_template.py
@@ -35,7 +35,7 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
     iac_git_project_name = f"dapla-team-{uniform_team_name}"
     domain = "@groups.ssb.no"
     mgm_group = f"{uniform_team_name}-managers{domain}"
-    dpo_group = f"{uniform_team_name}-data-admins{domain}"
+    dad_group = f"{uniform_team_name}-data-admins{domain}"
     dev_group = f"{uniform_team_name}-developers{domain}"
     con_group = f"{uniform_team_name}-consumers{domain}"
     technical_details = {
@@ -244,7 +244,7 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
                     },
                     {
                         "type": "tableRow",
-                        "content": _table_group_cells(dpo_group, details.data_protection_officers)
+                        "content": _table_group_cells(dad_group, details.data_admins)
                     },
                     {
                         "type": "tableRow",
@@ -552,7 +552,7 @@ def _description(details: ProjectDetails, current_date: datetime.date = datetime
                         "content": [
                             {
                                 "type": "text",
-                                "text": f"    {dpo_group}"
+                                "text": f"    {dad_group}"
                             }
                         ]
                     },

--- a/server/project_details.py
+++ b/server/project_details.py
@@ -12,7 +12,7 @@ class ProjectUser(BaseModel):
 class ProjectDetails(BaseModel):
     display_team_name: str
     manager: ProjectUser
-    data_protection_officers: Optional[List[ProjectUser]]
+    data_admins: Optional[List[ProjectUser]]
     developers: Optional[List[ProjectUser]]
     consumers: Optional[List[ProjectUser]]
     enabled_services: Optional[List[str]]

--- a/tests/adf_template_result.json
+++ b/tests/adf_template_result.json
@@ -245,7 +245,7 @@
                   "content": [
                     {
                       "type": "text",
-                      "text": "stubbe-data-protection-officers@groups.ssb.no"
+                      "text": "stubbe-data-admins@groups.ssb.no"
                     }
                   ]
                 }
@@ -679,7 +679,7 @@
           "content": [
             {
               "type": "text",
-              "text": "    stubbe-data-protection-officers@groups.ssb.no"
+              "text": "    stubbe-data-admins@groups.ssb.no"
             }
           ]
         },
@@ -733,7 +733,7 @@
       "content": [
         {
           "type": "text",
-          "text": "Etter at Kundeservice har satt opp agenten og opprettet en katalogstruktur på Linuxstammen kan du henvise til teamets Manager (Magnus Manager) og/eller en Data Protection Officer til følgende dokument som beskriver hvordan man setter opp Transfer Service på Google Cloud Platform:"
+          "text": "Etter at Kundeservice har satt opp agenten og opprettet en katalogstruktur på Linuxstammen kan du henvise til teamets Manager (Magnus Manager) og/eller en Data Admin til følgende dokument som beskriver hvordan man setter opp Transfer Service på Google Cloud Platform:"
         }
       ]
     },

--- a/tests/adf_template_result.json
+++ b/tests/adf_template_result.json
@@ -661,7 +661,7 @@
           "content": [
             {
               "type": "text",
-              "text": "Det nye dapla teamet 'Team Stubbe' trenger transfer service satt opp for seg."
+              "text": "Det nye Dapla teamet 'Team Stubbe' trenger Transfer Service satt opp for seg."
             }
           ]
         },
@@ -808,7 +808,7 @@
       "content": [
         {
           "type": "text",
-          "text": "display_team_name: Team Stubbe\nuniform_team_name: stubbe\ngithub_project_name: dapla-team-stubbe\n"
+          "text": "display_team_name: Team Stubbe\nuniform_team_name: stubbe\ngithub_repo_name: dapla-team-stubbe\n"
         }
       ]
     },

--- a/tests/test_jira_issue_adf_template.py
+++ b/tests/test_jira_issue_adf_template.py
@@ -11,7 +11,7 @@ def test_create_issue():
     project_details = ProjectDetails(
         display_team_name="Team Stubbe",
         manager=ProjectUser(name="Magnus Manager", email_short="mm@ssb.no", email="magnus.manager@ssb.no"),
-        data_protection_officers=[ProjectUser(name="Pernille Pilot", email_short="ppi@ssb.no", email="ppi@ssb.no"),
+        data_admins=[ProjectUser(name="Pernille Pilot", email_short="ppi@ssb.no", email="ppi@ssb.no"),
                                   ProjectUser(name="Petter Andrepilot ", email_short="pap@ssb.no", email="pap@ssb.no")],
         developers=[ProjectUser(name="Dorte Developer", email_short="dd@ssb.no", email="dd@ssb.no"),
                     ProjectUser(name="Diana Developer", email_short="did@ssb.no", email="did@ssb.no")],


### PR DESCRIPTION
dump yaml with unicode support

"github_repo_name" instead of project name.