### PR TITLE
Update Jira task

### DIFF
--- a/server/jira_issue_adf_template.py
+++ b/server/jira_issue_adf_template.py
@@ -701,7 +701,7 @@ def _description(details: ProjectDetails, current_date: date = None):
                             "type":
                             "text",
                             "text":
-                            f"I søkefeltet, søk etter teamet du nettopp opprettet ({uniform_team_name}-data-admins). Velg teamet og huk av for “Write” tilgang."
+                            f"I søkefeltet, søk etter teamet du nettopp opprettet ({uniform_team_name}-data-admins). Velg teamet og huk av for “Admin” tilgang."
                         }]
                     }]
                 }]

--- a/tests/adf_template_result.json
+++ b/tests/adf_template_result.json
@@ -1130,7 +1130,7 @@
               "content": [
                 {
                   "type": "text",
-                  "text": "I søkefeltet, søk etter teamet du nettopp opprettet (stubbs-data-admins). Velg teamet og huk av for “Write” tilgang."
+                  "text": "I søkefeltet, søk etter teamet du nettopp opprettet (stubbs-data-admins). Velg teamet og huk av for “Admin” tilgang."
                 }
               ]
             }


### PR DESCRIPTION
The data-admin group needs to be GitHub admins to connect the IAC-repo to Cloud Build when using the source-data-automation service. Updated the generated jira task to reflect this.