### PR TITLE
Add team section to customer support emails

### DIFF
--- a/server/jira_issue_adf_template.py
+++ b/server/jira_issue_adf_template.py
@@ -440,7 +440,7 @@ def _description(details: ProjectDetails, current_date: date = None):
                             "type":
                             "text",
                             "text":
-                            f"Det nye Dapla teamet '{details.display_team_name}' trenger AD grupper satt opp for seg og synkronisert til Google i sky. Dette betyr at gruppene skal inn i OU=SSB/Grupper/Skytjenester/BIP og må synkroniseres fra Azure Cloud til Google.",
+                            f"Det nye Dapla teamet '{details.display_team_name}' trenger AD grupper satt opp for seg og synkronisert til Google i sky. Dette betyr at gruppene skal inn i OU=SSB/Grupper/Skytjenester/BIP og må synkroniseres fra Azure Cloud til Google. Teamet tilhører seksjon: {details.org_info.name if details.org_info else '-'} ({details.org_info.code if details.org_info else '-'})",
                         }],
                     },
                     {
@@ -1185,7 +1185,7 @@ def _description(details: ProjectDetails, current_date: date = None):
                             "text":
                             f"Det nye Dapla teamet '{details.display_team_name}' trenger Transfer "
                             f"Service satt opp for seg. Johnny Niklasson, Tore Vestbekken eller Stian "
-                            f"Henriksen på Kundeservice kan utføre jobben.",
+                            f"Henriksen på Kundeservice kan utføre jobben. Teamet tilhører seksjon: {details.org_info.name if details.org_info else '-'} ({details.org_info.code if details.org_info else '-'})",
                         }],
                     },
                     {

--- a/tests/adf_template_result.json
+++ b/tests/adf_template_result.json
@@ -589,7 +589,7 @@
           "content": [
             {
               "type": "text",
-              "text": "Det nye Dapla teamet 'Team Stubbe' trenger AD grupper satt opp for seg og synkronisert til Google i sky. Dette betyr at gruppene skal inn i OU=SSB/Grupper/Skytjenester/BIP og må synkroniseres fra Azure Cloud til Google."
+              "text": "Det nye Dapla teamet 'Team Stubbe' trenger AD grupper satt opp for seg og synkronisert til Google i sky. Dette betyr at gruppene skal inn i OU=SSB/Grupper/Skytjenester/BIP og må synkroniseres fra Azure Cloud til Google. Teamet tilhører seksjon: Seksjon 11 (11)"
             }
           ]
         },
@@ -1596,7 +1596,7 @@
           "content": [
             {
               "type": "text",
-              "text": "Det nye Dapla teamet 'Team Stubbe' trenger Transfer Service satt opp for seg. Johnny Niklasson, Tore Vestbekken eller Stian Henriksen på Kundeservice kan utføre jobben."
+              "text": "Det nye Dapla teamet 'Team Stubbe' trenger Transfer Service satt opp for seg. Johnny Niklasson, Tore Vestbekken eller Stian Henriksen på Kundeservice kan utføre jobben. Teamet tilhører seksjon: Seksjon 11 (11)"
             }
           ]
         },


### PR DESCRIPTION
Add team section to customer support emails.

Customer service requested that we provide this information, when onboarding new teams.