### PR TITLE
Update repo ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in the repo.
 # They will be requested for review when someone opens a pull request.
-* @statisticsnorway/team-statistikktjenester
+* @statisticsnorway/dapla-stat-developers


### PR DESCRIPTION
The dapla-stat-developers group now owns this repo

Internal ref: [UTVIK-219]

[UTVIK-219]: https://statistics-norway.atlassian.net/browse/UTVIK-219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ